### PR TITLE
Adds isShortAnswerEnabled field

### DIFF
--- a/Sources/GraphQLClient/DataModels/GameSessionQuestion.swift
+++ b/Sources/GraphQLClient/DataModels/GameSessionQuestion.swift
@@ -22,6 +22,7 @@ public struct GameSessionQuestion: Codable {
     public var order: Int
     public var isHintEnabled: Bool
     public var isConfidenceEnabled: Bool
+    public var isShortAnswerEnabled: Bool
 
     init(from question: Question, order: Int) {
         self.id = question.id
@@ -35,7 +36,8 @@ public struct GameSessionQuestion: Codable {
         self.text = question.text
         self.order = order
         self.isHintEnabled = false
-        self.isConfidenceEnabled = false
+        self.isConfidenceEnabled = true
+        self.isShortAnswerEnabled = false
     }
 
     public init(from decoder: Decoder) throws {
@@ -60,5 +62,6 @@ public struct GameSessionQuestion: Codable {
         self.order = try container.decode(Int.self, forKey: .order)
         self.isHintEnabled = try container.decode(Bool.self, forKey: .isHintEnabled)
         self.isConfidenceEnabled = try container.decode(Bool.self, forKey: .isConfidenceEnabled)
+        self.isShortAnswerEnabled = try container.decode(Bool.self, forKey: .isShortAnswerEnabled)
     }
 }

--- a/Sources/GraphQLClient/Network/Models/CreateQuestionInput.swift
+++ b/Sources/GraphQLClient/Network/Models/CreateQuestionInput.swift
@@ -21,6 +21,7 @@ struct CreateQuestionInput {
     var order: Int
     var isHintEnabled: Bool
     var isConfidenceEnabled: Bool
+    var isShortAnswerEnabled: Bool
 
     init(gameSessionId: GameSessionID, question: Question, order: Int) {
         self.gameSessionId = gameSessionId
@@ -39,6 +40,7 @@ struct CreateQuestionInput {
         self.text = question.text
         self.order = order
         self.isHintEnabled = false
-        self.isConfidenceEnabled = false
+        self.isConfidenceEnabled = true
+        self.isShortAnswerEnabled = false
     }
 }

--- a/Sources/GraphQLClient/Network/Operations/CreateQuestionOperation.swift
+++ b/Sources/GraphQLClient/Network/Operations/CreateQuestionOperation.swift
@@ -23,6 +23,7 @@ struct CreateQuestionOperation: GQLOperationProtocol {
     private static let orderVariable = "order"
     private static let isHintEnabled = "isHintEnabled"
     private static let isConfidenceEnabled = "isConfidenceEnabled"
+    private static let isShortAnswerEnabled = "isShortAnswerEnabled"
 
     let input: CreateQuestionInput
 
@@ -53,6 +54,7 @@ struct CreateQuestionOperation: GQLOperationProtocol {
             Self.orderVariable: .int(input.order),
             Self.isHintEnabled: .bool(input.isHintEnabled),
             Self.isConfidenceEnabled: .bool(input.isConfidenceEnabled),
+            Self.isShortAnswerEnabled: .bool(input.isShortAnswerEnabled),
         ]
     }
 }
@@ -74,6 +76,7 @@ mutation createQuestion(
     $\(Self.orderVariable): Int!,
     $\(Self.isHintEnabled): Boolean!,
     $\(Self.isConfidenceEnabled): Boolean!
+    $\(Self.isShortAnswerEnabled): Boolean!
 ) {
     createQuestion(
         input: {
@@ -90,6 +93,7 @@ mutation createQuestion(
             \(Self.orderVariable): $\(Self.orderVariable)
             \(Self.isHintEnabled): $\(Self.isHintEnabled)
             \(Self.isConfidenceEnabled): $\(Self.isConfidenceEnabled)
+            \(Self.isShortAnswerEnabled): $\(Self.isShortAnswerEnabled)
         }
     ) {
         \(Self.idVariable)
@@ -105,6 +109,7 @@ mutation createQuestion(
         \(Self.orderVariable)
         \(Self.isHintEnabled)
         \(Self.isConfidenceEnabled)
+        \(Self.isShortAnswerEnabled)
     }
 }
 """


### PR DESCRIPTION
**Issue:**
As part of the PWA 1.1 features, we are implementing a Short Answer Response answering mode. This is an option that the teacher will select on a per question basis (similar to isHintEnabled and isConfidenceEnabled) and so the CreateGameSesssion lambda needs to be updated to be able to process this.

**Changes:**
-`isShortAnswerEnabled` has been added to all locations where `isConfidenceEnabled` and `isHintEnabled`
-`isConfidenceEnabled` has been defaulted to `true` per discussions with product teams. 