### PR TITLE
Adjust GraphQL endpoint based on Staging configuration

### DIFF
--- a/Sources/CreateGameSession/main.swift
+++ b/Sources/CreateGameSession/main.swift
@@ -59,6 +59,7 @@ let jsonDecoder = JSONDecoder()
 
 Lambda.run { (context, request: APIGateway.V2.Request, callback: @escaping (Result<APIGateway.V2.Response, Error>) -> Void) in
     Task {
+        let stage = request.context.stage
         guard
             request.context.http.path.hasSuffix("/createGameSession"),
             case .POST = request.context.http.method
@@ -81,7 +82,7 @@ Lambda.run { (context, request: APIGateway.V2.Request, callback: @escaping (Resu
         }
 
         do {
-            let gameSession = try await createGameSession(gameId: request.gameId, isAdvancedMode: request.isAdvancedMode)
+            let gameSession = try await createGameSession(gameId: request.gameId, isAdvancedMode: request.isAdvancedMode, stage: stage)
             callback(.success(
                 .init(
                     statusCode: .created,
@@ -97,8 +98,8 @@ Lambda.run { (context, request: APIGateway.V2.Request, callback: @escaping (Resu
     }
 }
 
-func createGameSession(gameId: Int, isAdvancedMode: Bool) async throws-> GameSession {
-    let api = ClientAPI()
+func createGameSession(gameId: Int, isAdvancedMode: Bool, stage: String) async throws-> GameSession {
+    let api = ClientAPI(stage: stage)
     let game = try await api.fetchGameAsync(id: gameId)
 
     let totalAnswersPerQuestion = 4


### PR DESCRIPTION
We are moving from a single development environment to having a main environment (accessible via APP.rightoneducation.com) and a testing environment (accessible via test-APP. rightoneducation.com). To facilitate this, the Lambda function needs to point at the correct GraphQL endpoint. To do so, we have set up two staging configurations for the Gateway API (see `createGameSession` API Gateway, Deploy -> Stages, in the AWS console). The apps in the respective environments have been adjusted to target each of these staging api gateway addresses so that it is possible to determine which GraphQL API endpoint to forward. This code update reveals the staging from `context` and then passes that down to the ClientAPI. 

It should be noted that in `GraphQLEndpoint+Keys.swift` (the local file that holds the API endpoints and API Keys), we have made the following changes:

```
import Foundation

extension ClientAPI.GraphQLEndpoint {
    static let web = Self(url: "RDS ENDPOINT URL", apiKey: "RDS API KEY")
    static func mobile (for stage: String) -> Self {
        switch stage {
        case "staging":
            return Self(url: "STAGING ENDPOINT URL", apiKey: "STAGING API KEY")
        case "testing":
            return Self(url: "TESTING ENDPOINT URL", apiKey: "TESTING API KEY")
        default:
            fatalError("Invalid API Gateway stage provided for Mobile")
        }
    }
}
```